### PR TITLE
upgrade webpack-cli version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "style-loader": "^0.20.3",
     "url-loader": "^1.0.1",
     "webpack": "^4.5.0",
-    "webpack-cli": "^2.0.14",
-    "webpack-dev-server": "^3.1.3"
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {
     "@tensorflow/tfjs": "^0.9.0",


### PR DESCRIPTION
In the old version, an error is reported during run, and the error log is as follows
```
0 info it worked if it ends with ok
1 verbose cli [ '/usr/local/Cellar/node/11.4.0/bin/node',
1 verbose cli   '/usr/local/bin/npm',
1 verbose cli   'start' ]
2 info using npm@6.5.0
3 info using node@v11.4.0
4 verbose run-script [ 'prestart', 'start', 'poststart' ]
5 info lifecycle t-rex-run@1.0.0~prestart: t-rex-run@1.0.0
6 info lifecycle t-rex-run@1.0.0~start: t-rex-run@1.0.0
7 verbose lifecycle t-rex-run@1.0.0~start: unsafe-perm in lifecycle true
8 verbose lifecycle t-rex-run@1.0.0~start: PATH: /usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/node-gyp-bin:/Users/toquery/Project/tensorflow-rex-run/node_modules/.bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/aria2/bin:/usr/local/MacGPG2/bin:/Applications/Wireshark.app/Contents/MacOS
9 verbose lifecycle t-rex-run@1.0.0~start: CWD: /Users/toquery/Project/tensorflow-rex-run
10 silly lifecycle t-rex-run@1.0.0~start: Args: [ '-c', 'webpack-dev-server --mode development' ]
11 silly lifecycle t-rex-run@1.0.0~start: Returned: code: 1  signal: null
12 info lifecycle t-rex-run@1.0.0~start: Failed to exec start script
13 verbose stack Error: t-rex-run@1.0.0 start: `webpack-dev-server --mode development`
13 verbose stack Exit status 1
13 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/index.js:301:16)
13 verbose stack     at EventEmitter.emit (events.js:189:13)
13 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/npm-lifecycle/lib/spawn.js:55:14)
13 verbose stack     at ChildProcess.emit (events.js:189:13)
13 verbose stack     at maybeClose (internal/child_process.js:978:16)
13 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:265:5)
14 verbose pkgid t-rex-run@1.0.0
15 verbose cwd /Users/toquery/Project/tensorflow-rex-run
16 verbose Darwin 18.0.0
17 verbose argv "/usr/local/Cellar/node/11.4.0/bin/node" "/usr/local/bin/npm" "start"
18 verbose node v11.4.0
19 verbose npm  v6.5.0
20 error code ELIFECYCLE
21 error errno 1
22 error t-rex-run@1.0.0 start: `webpack-dev-server --mode development`
22 error Exit status 1
23 error Failed at the t-rex-run@1.0.0 start script.
23 error This is probably not a problem with npm. There is likely additional logging output above.
24 verbose exit [ 1, true ]
```